### PR TITLE
Changes to calendar_display.php and additions to calender-default.css

### DIFF
--- a/calendar_display.php
+++ b/calendar_display.php
@@ -25,18 +25,18 @@
     $dow = date("w", mktime(0, 0, 0, $month, 1, $year));
     if ($dow == 0) {$dow = 7;}
     echo "<h4>$month_name $year</h4>";
-    echo "<table class='table table-striped table-bordered' width=99%><thead><th>Monday</th><th>Tuesday</th><th>Wednesday</th><th>Thursday</th><th>Friday</th>";
+    echo "<table class='table table-striped table-bordered calendar'><thead><tr><th>Monday</th><th>Tuesday</th><th>Wednesday</th><th>Thursday</th><th>Friday</th>";
     if ($WEEKENDS) {
       echo "<th>Saturday</th><th>Sunday</th>";
     }
-    echo "</thead><tbody>";
+    echo "</tr></thead><tbody>";
     $week_open = False;
     if (($dow != 1 && $dow < 6) || $WEEKENDS) {
-      echo "<tr valign=top>";
+      echo "<tr>";
       $week_open = True;
       for ($spacer = 1; ($spacer < $dow); $spacer++) {
         if ($spacer < 6 || ($WEEKENDS && $spacer < 8)) {
-          echo "<td width=$box_width% bgcolor='#eaeaea'>&nbsp; </td>";
+          echo "<td class='spacer-day'>&nbsp; </td>";
         }
       }
     }
@@ -49,22 +49,22 @@
          ) {
         if ($WEEKENDS || $dow < 6) {
           if (!$week_open) {
-            echo "<tr valign=top>";
+            echo "<tr>";
             $week_open = True;
           }
           if ($today['year'] == $year && $today['mon'] == $month && $today['mday'] == $day) {
-            echo "<td valign=top width=$box_width% bgcolor='#FFFEBD'><a name='today'></a>";
+            echo "<td class='today-day'><a name='today'></a>";
           } else {
-            echo "<td valign=top width=$box_width%>";
+            echo "<td>";
           }
           if ($INSTRUCTOR && isset($events_list[$month][$day]['type']) && isset($events_list[$month][$day]['type_num'])) {
-            echo "<a href=calendar.php?navbaronly=1&type=".$events_list[$month][$day]['type']."&event=".$events_list[$month][$day]['type_num'].">";
+            echo "<a href='calendar.php?navbaronly=1&type=".$events_list[$month][$day]['type']."&event=".$events_list[$month][$day]['type_num']."'>";
           }
           echo "$day ";
-          if ($INSTRUCTOR) {
+          if ($INSTRUCTOR && isset($events_list[$month][$day]['type']) && isset($events_list[$month][$day]['type_num'])) {
             echo "</a>";
           }
-          echo "<center>";
+          echo "<div class='content-center-day'>";
           if (isset($events_list[$month][$day])) {
             echo "<b>" . strtoupper($events_list[$month][$day]['type']) . ' ' . $events_list[$month][$day]['type_num'] . "</b><br>";
             foreach($box as $i => $btype) {
@@ -74,14 +74,14 @@
               }
               if ($btype == 'title') {
                 if (isset($events_list[$month][$day]['event']['box'][$btype])) {
-                  echo "<a href=calendar.php?type=" . $events_list[$month][$day]['type'] . "&event=" . $events_list[$month][$day]['type_num'] . ">";
+                  echo "<a href='calendar.php?type=" . $events_list[$month][$day]['type'] . "&event=" . $events_list[$month][$day]['type_num'] . "'>";
                   echo $events_list[$month][$day]['event']['name'];
                   echo "</a>";
                   if (!$events_list[$month][$day]['event']['box'][$btype]['visible']) {
                     $fyear= $events_list[$month][$day]['event']['box'][$btype]['year'];
                     $fmon = $events_list[$month][$day]['event']['box'][$btype]['month'];
                     $fday = $events_list[$month][$day]['event']['box'][$btype]['day'];
-                    echo " <font color='purple'>($fmon/$fday/$fyear)</font>";
+                    echo " <span class='reveal-date-day'>($fmon/$fday/$fyear)</span>";
                   }
                 } elseif (isset($events_list[$month][$day]['event']['name'])) {
                   echo $events_list[$month][$day]['event']['name'];
@@ -98,12 +98,12 @@
                     $key = $events_list[$month][$day]['event']['box'][$btype]['key'];
                     $ftype = $events_list[$month][$day]['event']['box'][$btype]['ftype'];
                     $fclass = $events_list[$month][$day]['event']['box'][$btype]['fclass'];
-                    echo "<a href=calendar.php?key=$key&type=$ftype&event=$fclass>$btype_desc</a>";
+                    echo "<a href='calendar.php?key=$key&type=$ftype&event=$fclass'>$btype_desc</a>";
                     if (!$events_list[$month][$day]['event']['box'][$btype]['visible']) {
                       $fyear= $events_list[$month][$day]['event']['box'][$btype]['year'];
                       $fmon = $events_list[$month][$day]['event']['box'][$btype]['month'];
                       $fday = $events_list[$month][$day]['event']['box'][$btype]['day'];
-                      echo " <font color='purple'>($fmon/$fday/$fyear)</font>";
+                      echo " <span class='reveal-date-day'>($fmon/$fday/$fyear)</span>";
                     }
 
                   }
@@ -125,14 +125,14 @@
                   }
                   if ($btype == 'title') {
                     if (isset($new_eventsdata['event']['box'][$btype])) {
-                      echo "<a href=calendar.php?type=" . $new_eventsdata['type'] . "&event=" . $new_eventsdata['type_num'] . ">";
+                      echo "<a href='calendar.php?type=" . $new_eventsdata['type'] . "&event=" . $new_eventsdata['type_num'] . "'>";
                       echo $new_eventsdata['event']['name'];
                       echo "</a>";
                       if (!$new_eventsdata['event']['box'][$btype]['visible']) {
                         $fyear= $new_eventsdata['event']['box'][$btype]['year'];
                         $fmon = $new_eventsdata['event']['box'][$btype]['month'];
                         $fday = $new_eventsdata['event']['box'][$btype]['day'];
-                        echo " <font color='purple'>($fmon/$fday/$fyear)</font>";
+                        echo " <span class='reveal-date-day'>($fmon/$fday/$fyear)</span>";
                       }
                     } elseif (isset($new_eventsdata['event']['name'])) {
                       echo $new_eventsdata['event']['name'];
@@ -149,12 +149,12 @@
                         $key = $new_eventsdata['event']['box'][$btype]['key'];
                         $ftype = $new_eventsdata['event']['box'][$btype]['ftype'];
                         $fclass = $new_eventsdata['event']['box'][$btype]['fclass'];
-                        echo "<a href=calendar.php?key=$key&type=$ftype&event=$fclass>$btype_desc</a>";
+                        echo "<a href='calendar.php?key=$key&type=$ftype&event=$fclass'>$btype_desc</a>";
                         if (!$new_eventsdata['event']['box'][$btype]['visible']) {
                           $fyear= $new_eventsdata['event']['box'][$btype]['year'];
                           $fmon = $new_eventsdata['event']['box'][$btype]['month'];
                           $fday = $new_eventsdata['event']['box'][$btype]['day'];
-                          echo " <font color='purple'>($fmon/$fday/$fyear)</font>";
+                          echo " <span class='reveal-date-day'>($fmon/$fday/$fyear)</span>";
                         }
                       }
                       echo "<br>";
@@ -168,7 +168,7 @@
           } else {
             echo "<br><br><br><br><br><br><br><br>";
           }
-          echo "</center></td>";
+          echo "</div></td>";
         }
         $dow++;
         if ($dow > 7) {

--- a/css/calendar-default.css
+++ b/css/calendar-default.css
@@ -270,4 +270,49 @@ code {
   .table-borderless > thead > tr > th {
       border: none;
     }
+
+/*added 20180531 by Dan Burnham to "fix" styling of the calendar table. 
+   By adding calendar as a class to the top level calendar table for each month,
+   this allows replacement of the:
+       width=20%
+       valigh=top 
+   in the <td> and <th> tags, which are obsolete in HTML5. */
+  table.table.table-striped.table-bordered.calendar > thead > tr > th,
+  table.table.table-striped.table-bordered.calendar > thead > tr > td,
+  table.table.table-striped.table-bordered.calendar > tbody > tr > th,
+  table.table.table-striped.table-bordered.calendar > tbody > tr > td,
+  table.table.table-striped.table-bordered.calendar > tfoot > tr > th,
+  table.table.table-striped.table-bordered.calendar > tfoot > tr > td {
+    width: 20%;
+    vertical-align: top;
+  }
+  /*This allows the removal of the valign=top from all <tr> elements. */
+  table.table.table-striped.table-bordered.calendar > thead > tr,
+  table.table.table-striped.table-bordered.calendar > tbody > tr,
+  table.table.table-striped.table-bordered.calendar > tfoot > tr {
+    vertical-align: top; 
+  }
+
+  /*This addition allows for spacer days in the begining of the month to have a background
+     color different than the "normal" days. */
+  table.table.table-striped.table-bordered.calendar > tbody > tr > td.spacer-day {
+    background-color: #eaeaea;
+  }
+
+  /*This addition sets the color for the current day on the calendar. */
+  table.table.table-striped.table-bordered.calendar > tbody > tr > td.today-day {
+    background-color: #fffebd;
+  }  
+
+  /*This addition sets the new div that replaced the center element to have text centered. */
+  table.table.table-striped.table-bordered.calendar > tbody > tr > td > div.content-center-day {
+    text-align: center;
+  }  
+
+  /*This addition set the text color to purple for the text on the date the item is to be revealed. */
+  .reveal-date-day {
+    color: purple;
+  }
+
+
 }


### PR DESCRIPTION
Here are the changes made to calendar_display.php and why:

Line 28: Missing <tr> and </tr> element after <thead>. Added 20180531

Line 61: Resulting link does not have quotes after href=, so added single quote marks 20180531
echo "<a href='calendar.php?navbaronly=1&type=".$events_list[$month][$day]['type']."&event=".$events_list[$month][$day]['type_num']."'>";

Line 64: This checks if($INSTRUCTOR) and if so puts a closing </a> tag in place after the day number. HOWEVER, this causes there to be a closing tag with no opening tag if there is no content for that day.
Added the additional conditions from line 60 to this as well to get:
if ($INSTRUCTOR && isset($events_list[$month][$day]['type']) && isset($events_list[$month][$day]['type_num'])) {
That appears to have fixed the issue when run through a validator.

Line 60: The resulting hyperlink will have a space in it if the type has a space in it. While this sounds dumb, to get something like "Project 1" or "Lab Topic Email Due 1200" to show up in bold in a particular day of the calendar it ends up being treated as a type, which then causes this to occur.
No fix done at this time...


Line 77: Same type of fix for the href= missing quotes as Line 61. Added 20180531
echo "<a href='calendar.php?type=" . $events_list[$month][$day]['type'] . "&event=" . $events_list[$month][$day]['type_num'] . "'>";

Line 101: Same type of fix for the href= missing quotes as Line 61. Added 20180531
echo "<a href='calendar.php?key=$key&type=$ftype&event=$fclass'>$btype_desc</a>";

Line 128: Same type of fix for the href= missing quotes as Line 61. Added 20180531
echo "<a href='calendar.php?type=" . $new_eventsdata['type'] . "&event=" . $new_eventsdata['type_num'] . "'>";

Line 152: Same type of fix for the href= missing quotes as Line 61. Added 20180531
echo "<a href='calendar.php?key=$key&type=$ftype&event=$fclass'>$btype_desc</a>";

Line 28: Added the class calendar to the list of classes for the table. 20180531 This then calls the CSS which adds the width and text alignment.

Line 39: Removed width=$box_width% bgcolor='#eaeaea' and put class='spacer-day' in its place. This will cause the CSS added to calendar-default.css to add the values back in. The bgcolor attribute is obsolete in HTML5.

Line 35: Removed valign=top from <tr> element.
Line 52: Removed valign=top from <tr> element.

Line 56: Removed bgcolor='#FFFEBD' and replaced with class='today-day'. This will cause the CSS added to calendar-default.css to add the color back in as the bgcolor attribute is obsolete in HTML5.

Line 56: Removed valign=top width=$box_width% from <td> element.
Line 58: Removed valign=top width=$box_width% from <td> element.

Line 28: Removed width=99%. Value was set to 100% by tables.less anyway and width is an obsolete attribute in HTML5.

Line 67: Replaced the <center> element with <div class='content-center-day'> which will cause the added CSS in calendar-default.css to center the content in the cell. DIDNT add text-align:center to <td> as that would affect the day of the week which is to be in the upper left hand corner. The <center> element is obsolete in HTML5.

Line 84: Replaced <font color='purple'> with <span class='reveal-date-day'> which will cause the added CSS in calendar-default.css to make the color of the date purple. The <font> element is obsolete in HTML5.
Line 106: same
Line 135: same
Line 157: same

Line 28: Removed the added </tr> from here as it would cause issues if weekends were selected.
Line 32: Added the </tr> here.

Line 175/183: There can be occurances when there ends up a stray </tr> tag from here. DIDNT FIX.
