### PR TITLE
Modified calendar_main.php so that the codeinject tag now will work w…

### DIFF
--- a/calendar_main.php
+++ b/calendar_main.php
@@ -849,6 +849,8 @@
         $inject_data = str_ireplace('>', '&gt;', $inject_data);
         $contents = str_ireplace('<codeinject src="'.$tag_src.'">', $inject_data, $contents);
         $contents = str_ireplace("<codeinject src='$tag_src'>", $inject_data, $contents);
+        $contents = str_ireplace('<codeinject src="'.$tag_src.'"/>', $inject_data, $contents);
+        $contents = str_ireplace("<codeinject src='$tag_src'"."/>", $inject_data, $contents);
       }
     }
   }


### PR DESCRIPTION
…ith a closing mark in it. For example, <codeinject src='mycode'/> will now work correctly. This fix was put in because some editors do not highlight syntax correctly if there is no closing tag or mark for a tag.